### PR TITLE
Add helper to test if device has v2 API

### DIFF
--- a/homewizard_energy/__init__.py
+++ b/homewizard_energy/__init__.py
@@ -1,5 +1,7 @@
 """HomeWizard Energy API library."""
 
+from aiohttp import ClientSession
+
 from .errors import DisabledError, InvalidStateError, RequestError, UnsupportedError
 from .v1 import HomeWizardEnergyV1
 from .v2 import HomeWizardEnergyV2
@@ -12,3 +14,24 @@ __all__ = [
     "RequestError",
     "UnsupportedError",
 ]
+
+
+async def has_v2_api(host: str, websession: ClientSession | None = None) -> bool:
+    """Check if the device has support for the v2 api."""
+    websession_provided = websession is not None
+    if websession is None:
+        websession = ClientSession()
+    try:
+        # v2 api is https only and returns a 401 Unauthorized when no key provided,
+        # no connection can be made if the device is not v2
+        url = f"https://{host}/api"
+        async with websession.get(
+            url, ssl=False, raise_for_status=False, timeout=15
+        ) as res:
+            return res.status == 401
+    except Exception:  # pylint: disable=broad-except
+        # all other status/exceptions means the device is not v2 or not reachable at this time
+        return False
+    finally:
+        if not websession_provided:
+            await websession.close()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,68 @@
+"""Test the helper functions."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import ClientSession
+
+from homewizard_energy import has_v2_api
+
+pytestmark = [pytest.mark.asyncio]
+
+
+async def test_has_v2_api_true(aresponses):
+    """Test if has_v2_api returns True for a v2 device."""
+
+    aresponses.add(
+        "example.com",
+        "/api",
+        "GET",
+        aresponses.Response(
+            status=401,
+        ),
+    )
+
+    async with ClientSession() as session:
+        result = await has_v2_api("example.com", session)
+        assert result is True
+
+
+async def test_has_v2_api_false(aresponses):
+    """Test if has_v2_api returns False for a non-v2 device."""
+    aresponses.add(
+        "example.com",
+        "/api",
+        "GET",
+        aresponses.Response(
+            status=404,
+        ),
+    )
+
+    async with ClientSession() as session:
+        result = await has_v2_api("example.com", session)
+        assert result is False
+
+
+async def test_has_v2_api_exception():
+    """Test if has_v2_api returns False when an exception occurs."""
+    session = AsyncMock()
+    session.request = AsyncMock(side_effect=asyncio.TimeoutError())
+
+    result = await has_v2_api("example.com", session)
+    assert result is False
+
+
+async def test_has_v2_api_own_session(aresponses):
+    """Test if has_v2_api opens and closes its own session."""
+    aresponses.add(
+        "example.com",
+        "/api",
+        "GET",
+        aresponses.Response(
+            status=401,
+        ),
+    )
+
+    result = await has_v2_api("example.com")
+    assert result is True


### PR DESCRIPTION
SSIA

A helper that can be used to test if device supports v2 by simply trying

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an asynchronous function to check device compatibility with the v2 API.
  
- **Tests**
	- Added a comprehensive test suite for the new function, covering various scenarios including successful detection, failure responses, exception handling, and session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->