### PR TITLE
Add helper to get hostname validation string from model and serial id

### DIFF
--- a/homewizard_energy/__init__.py
+++ b/homewizard_energy/__init__.py
@@ -35,3 +35,23 @@ async def has_v2_api(host: str, websession: ClientSession | None = None) -> bool
     finally:
         if not websession_provided:
             await websession.close()
+
+
+def get_verification_hostname(model: str, serial_number: str) -> str:
+    """Get the verification name for the device."""
+    model_map = {
+        "HWE-P1": "p1dongle",
+        "HWE-SKT": "energysocket",
+        "HWE-WTR": "watermeter",
+        "HWE-DSP": "display",
+        "HWE-KWH1": "energymeter",
+        "SDM230-wifi": "energymeter",
+        "HWE-KWH3": "energymeter",
+        "SDM630-wifi": "energymeter",
+        "HWE-BAT": "battery",
+    }
+
+    if model not in model_map:
+        raise ValueError(f"Unsupported model: {model}")
+
+    return f"appliance/{model_map[model]}/{serial_number}"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 from aiohttp import ClientSession
 
-from homewizard_energy import has_v2_api
+from homewizard_energy import get_verification_hostname, has_v2_api
 
 pytestmark = [pytest.mark.asyncio]
 
@@ -66,3 +66,31 @@ async def test_has_v2_api_own_session(aresponses):
 
     result = await has_v2_api("example.com")
     assert result is True
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("HWE-P1", "appliance/p1dongle/1234567890"),
+        ("HWE-SKT", "appliance/energysocket/1234567890"),
+        ("HWE-WTR", "appliance/watermeter/1234567890"),
+        ("HWE-DSP", "appliance/display/1234567890"),
+        ("HWE-KWH1", "appliance/energymeter/1234567890"),
+        ("SDM230-wifi", "appliance/energymeter/1234567890"),
+        ("HWE-KWH3", "appliance/energymeter/1234567890"),
+        ("SDM630-wifi", "appliance/energymeter/1234567890"),
+        ("HWE-BAT", "appliance/battery/1234567890"),
+    ],
+)
+async def test_get_verification_hostname_returns_expected_identifier(
+    model: str, expected: str
+):
+    """Test if get_verification_hostname returns the expected identifier."""
+    result = get_verification_hostname(model, "1234567890")
+    assert result == expected
+
+
+def test_get_verification_hostname_raises_value_error():
+    """Test if get_verification_hostname raises a ValueError for an unsupported model."""
+    with pytest.raises(ValueError):
+        get_verification_hostname("unsupported", "1234567890")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a function to retrieve verification names for devices based on model and serial number.
  
- **Tests**
	- Added new test cases to validate the functionality of the verification hostname retrieval, including checks for expected outputs and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->