### PR TITLE
Move LOGGER to const.py

### DIFF
--- a/homewizard_energy/const.py
+++ b/homewizard_energy/const.py
@@ -1,0 +1,5 @@
+"""Constants for HomeWizard Energy."""
+
+import logging
+
+LOGGER = logging.getLogger(__name__)

--- a/homewizard_energy/models.py
+++ b/homewizard_energy/models.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -12,7 +11,7 @@ from mashumaro.config import BaseConfig
 from mashumaro.exceptions import MissingField
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-_LOGGER = logging.getLogger(__name__)
+from .const import LOGGER
 
 
 class BaseModel(DataClassORJSONMixin):
@@ -291,7 +290,7 @@ class Measurement(BaseModel):
             try:
                 device = ExternalDevice.from_dict(item)
             except MissingField as e:
-                _LOGGER.error("Error converting external device: %s", e)
+                LOGGER.error("Error converting external device: %s", e)
                 continue
             rv[f"{device.type}_{device.unique_id}"] = device
 

--- a/homewizard_energy/v1/__init__.py
+++ b/homewizard_energy/v1/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 from collections.abc import Callable, Coroutine
 from http import HTTPStatus
 from typing import Any, TypeVar
@@ -20,10 +19,9 @@ from homewizard_energy.errors import (
     UnsupportedError,
 )
 
+from ..const import LOGGER
 from ..models import Device, Measurement, State, System
 from .const import SUPPORTED_API_VERSION
-
-_LOGGER = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
@@ -115,7 +113,7 @@ class HomeWizardEnergyV1:
             state["brightness"] = brightness
 
         if not state:
-            _LOGGER.error("At least one state update is required")
+            LOGGER.error("At least one state update is required")
             return False
 
         await self.request("api/v1/state", method=METH_PUT, data=state)
@@ -138,7 +136,7 @@ class HomeWizardEnergyV1:
             state["cloud_enabled"] = cloud_enabled
 
         if not state:
-            _LOGGER.error("At least one state update is required")
+            LOGGER.error("At least one state update is required")
             return False
 
         await self.request("api/v1/system", method=METH_PUT, data=state)
@@ -164,7 +162,7 @@ class HomeWizardEnergyV1:
         url = f"http://{self.host}/{path}"
         headers = {"Content-Type": "application/json"}
 
-        _LOGGER.debug("%s, %s, %s", method, url, data)
+        LOGGER.debug("%s, %s, %s", method, url, data)
 
         try:
             async with async_timeout.timeout(self._request_timeout):
@@ -174,7 +172,7 @@ class HomeWizardEnergyV1:
                     json=data,
                     headers=headers,
                 )
-                _LOGGER.debug("%s, %s", resp.status, await resp.text("utf-8"))
+                LOGGER.debug("%s, %s", resp.status, await resp.text("utf-8"))
         except asyncio.TimeoutError as exception:
             raise RequestError(
                 f"Timeout occurred while connecting to the HomeWizard Energy device at {self.host}"
@@ -202,7 +200,7 @@ class HomeWizardEnergyV1:
 
     async def close(self) -> None:
         """Close client session."""
-        _LOGGER.debug("Closing clientsession")
+        LOGGER.debug("Closing clientsession")
         if self._session and self._close_session:
             await self._session.close()
 

--- a/homewizard_energy/v2/__init__.py
+++ b/homewizard_energy/v2/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 import ssl
 from collections.abc import Callable, Coroutine
 from http import HTTPStatus
@@ -29,10 +28,9 @@ from homewizard_energy.errors import (
     UnauthorizedError,
 )
 
+from ..const import LOGGER
 from ..models import Device, Measurement, System, SystemUpdate, Token
 from .cacert import CACERT
-
-_LOGGER = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
@@ -204,7 +202,7 @@ class HomeWizardEnergyV2:
             if self._identifier is not None:
                 context.hostname_checks_common_name = True
             else:
-                _LOGGER.warning("No hostname provided, skipping hostname validation")
+                LOGGER.warning("No hostname provided, skipping hostname validation")
                 context.check_hostname = False  # Skip hostname validation
                 context.verify_mode = ssl.CERT_REQUIRED  # Keep SSL verification active
             return context
@@ -240,7 +238,7 @@ class HomeWizardEnergyV2:
         if self._token is not None:
             headers["Authorization"] = f"Bearer {self._token}"
 
-        _LOGGER.debug("%s, %s, %s", method, url, data)
+        LOGGER.debug("%s, %s, %s", method, url, data)
 
         try:
             async with async_timeout.timeout(self._request_timeout):
@@ -253,7 +251,7 @@ class HomeWizardEnergyV2:
                     if self._identifier is not None
                     else None,
                 )
-                _LOGGER.debug("%s, %s", resp.status, await resp.text("utf-8"))
+                LOGGER.debug("%s, %s", resp.status, await resp.text("utf-8"))
         except asyncio.TimeoutError as exception:
             raise RequestError(
                 f"Timeout occurred while connecting to the HomeWizard Energy device at {self.host}"
@@ -276,7 +274,7 @@ class HomeWizardEnergyV2:
 
     async def close(self) -> None:
         """Close client session."""
-        _LOGGER.debug("Closing clientsession")
+        LOGGER.debug("Closing clientsession")
         if self._clientsession is not None:
             await self._clientsession.close()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Standardized logging mechanism across the HomeWizard Energy module
	- Centralized logger configuration in a new `const.py` file
	- Replaced local logger instances with a centralized `LOGGER`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->