### PR TITLE
Reduce backoff retries to 3

### DIFF
--- a/homewizard_energy/v1/__init__.py
+++ b/homewizard_energy/v1/__init__.py
@@ -114,7 +114,7 @@ class HomeWizardEnergyV1(HomeWizardEnergy):
         await self._request("api/v1/identify", method=METH_PUT)
         return True
 
-    @backoff.on_exception(backoff.expo, RequestError, max_tries=5, logger=None)
+    @backoff.on_exception(backoff.expo, RequestError, max_tries=3, logger=None)
     async def _request(
         self, path: str, method: str = METH_GET, data: object = None
     ) -> tuple[HTTPStatus, dict[str, Any] | None]:

--- a/homewizard_energy/v2/__init__.py
+++ b/homewizard_energy/v2/__init__.py
@@ -211,7 +211,7 @@ class HomeWizardEnergyV2(HomeWizardEnergy):
             connector=connector, timeout=ClientTimeout(total=self._request_timeout)
         )
 
-    @backoff.on_exception(backoff.expo, RequestError, max_tries=5, logger=None)
+    @backoff.on_exception(backoff.expo, RequestError, max_tries=3, logger=None)
     async def _request(
         self, path: str, method: str = METH_GET, data: object = None
     ) -> tuple[HTTPStatus, dict[str, Any] | None]:

--- a/tests/v1/test_v1_homewizard_energy.py
+++ b/tests/v1/test_v1_homewizard_energy.py
@@ -560,7 +560,7 @@ async def test_system_set_unsupported_arguments():
 
 
 # pylint: disable=protected-access
-async def test_request_timeout():
+async def test_request_handles_timeout():
     """Test request raises timeout when request takes too long."""
 
     api = HomeWizardEnergyV1("example.com")
@@ -571,7 +571,7 @@ async def test_request_timeout():
         # pylint: disable=protected-access
         await api._request("api/v1/data")
 
-    assert api._session.request.call_count == 5
+    assert api._session.request.call_count == 3
 
 
 async def test_close_when_out_of_scope():

--- a/tests/v2/test_v2_homewizard_energy.py
+++ b/tests/v2/test_v2_homewizard_energy.py
@@ -525,7 +525,7 @@ async def test_request_handles_timeout():
         with pytest.raises(RequestError):
             await api.device()
 
-        assert api._session.request.call_count == 5
+        assert api._session.request.call_count == 3
 
 
 async def test_request_with_identifier_sets_common_name(aresponses):


### PR DESCRIPTION
Increases unit test speed and 3 times is enough; When it fails after 3 times it will fail after 5.