### PR TITLE
Remove API version check, as v1 API will never update

### DIFF
--- a/homewizard_energy/v1/__init__.py
+++ b/homewizard_energy/v1/__init__.py
@@ -24,7 +24,6 @@ from ..models import (
     System,
     SystemUpdate,
 )
-from .const import SUPPORTED_API_VERSION
 
 T = TypeVar("T")
 
@@ -73,11 +72,6 @@ class HomeWizardEnergyV1(HomeWizardEnergy):
         """Return the device object."""
         _, response = await self._request("api")
         device = Device.from_json(response)
-
-        if device.api_version != SUPPORTED_API_VERSION:
-            raise UnsupportedError(
-                f"Unsupported API version, expected version '{SUPPORTED_API_VERSION}'"
-            )
 
         return device
 

--- a/homewizard_energy/v1/const.py
+++ b/homewizard_energy/v1/const.py
@@ -1,6 +1,4 @@
 """Constants for HomeWizard Energy v1."""
 
-SUPPORTED_API_VERSION = "v1"
-
 SUPPORTS_STATE = ["HWE-SKT"]
 SUPPORTS_IDENTIFY = ["HWE-SKT", "HWE-P1", "HWE-WTR"]

--- a/tests/v1/test_v1_homewizard_energy.py
+++ b/tests/v1/test_v1_homewizard_energy.py
@@ -352,29 +352,6 @@ async def test_get_device_object(
             await api.close()
 
 
-async def test_get_device_object_detects_invalid_api(aresponses):
-    """Test raises error when invalid API is used."""
-
-    aresponses.add(
-        "example.com",
-        "/api",
-        "GET",
-        aresponses.Response(
-            text=load_fixtures("exceptions/device_invalid_api.json"),
-            status=200,
-            headers={"Content-Type": "application/json; charset=utf-8"},
-        ),
-    )
-
-    async with aiohttp.ClientSession() as session:
-        api = HomeWizardEnergyV1("example.com", clientsession=session)
-
-        with pytest.raises(UnsupportedError):
-            await api.device()
-
-        await api.close()
-
-
 @pytest.mark.parametrize(
     ("model", "fixtures"),
     [


### PR DESCRIPTION
Removed SUPPORTED_API_VERSION const, and remove the check.

The v1 API only works over http and will never update to v2. Only the HTTPS API will update to new versions in the future. Removing the v1 check simplifies the `device()` method