### PR TITLE
Cache 'device' model in device() method

### DIFF
--- a/homewizard_energy/homewizard_energy.py
+++ b/homewizard_energy/homewizard_energy.py
@@ -72,7 +72,7 @@ class HomeWizardEnergy:
             device=self._device, measurement=measurement, system=system, state=state
         )
 
-    async def device(self) -> Device:
+    async def device(self, reset_cache: bool = False) -> Device:
         """Get the device information."""
         raise NotImplementedError
 

--- a/homewizard_energy/v1/__init__.py
+++ b/homewizard_energy/v1/__init__.py
@@ -38,11 +38,17 @@ def optional_method(
 class HomeWizardEnergyV1(HomeWizardEnergy):
     """Communicate with a HomeWizard Energy device."""
 
-    async def device(self) -> Device:
+    async def device(self, reset_cache: bool = False) -> Device:
         """Return the device object."""
+
+        if self._device is not None and not reset_cache:
+            return self._device
+
         _, response = await self._request("api")
         device = Device.from_json(response)
 
+        # Cache device object
+        self._device = device
         return device
 
     async def measurement(self) -> Measurement:

--- a/homewizard_energy/v2/__init__.py
+++ b/homewizard_energy/v2/__init__.py
@@ -72,11 +72,16 @@ class HomeWizardEnergyV2(HomeWizardEnergy):
         self._token = token
 
     @authorized_method
-    async def device(self) -> Device:
+    async def device(self, reset_cache: bool = False) -> Device:
         """Return the device object."""
+        if self._device is not None and not reset_cache:
+            return self._device
+
         _, response = await self._request("/api")
         device = Device.from_json(response)
 
+        # Cache device object
+        self._device = device
         return device
 
     @authorized_method

--- a/tests/v1/test_v1_homewizard_energy.py
+++ b/tests/v1/test_v1_homewizard_energy.py
@@ -351,6 +351,73 @@ async def test_get_device_object(
             await api.close()
 
 
+async def test_get_device_used_cached_device_object(aresponses):
+    """Test device object is fetched and sets detected values."""
+
+    aresponses.add(
+        "example.com",
+        "/api",
+        "GET",
+        aresponses.Response(
+            text=load_fixtures("HWE-P1/device.json"),
+            status=200,
+            headers={"Content-Type": "application/json; charset=utf-8"},
+        ),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        api = HomeWizardEnergyV1("example.com", clientsession=session)
+        device = await api.device()
+
+        assert device
+        assert device.product_type == "HWE-P1"
+
+        device_2 = await api.device()
+        assert device_2 == device
+
+        await api.close()
+
+
+async def test_get_device_with_clear_cache_flag(aresponses):
+    """Test device object is fetched and sets detected values."""
+
+    aresponses.add(
+        "example.com",
+        "/api",
+        "GET",
+        aresponses.Response(
+            text=load_fixtures("HWE-P1/device.json"),
+            status=200,
+            headers={"Content-Type": "application/json; charset=utf-8"},
+        ),
+    )
+
+    aresponses.add(
+        "example.com",
+        "/api",
+        "GET",
+        aresponses.Response(
+            text=load_fixtures("HWE-SKT/device.json"),
+            status=200,
+            headers={"Content-Type": "application/json; charset=utf-8"},
+        ),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        api = HomeWizardEnergyV1("example.com", clientsession=session)
+        device = await api.device()
+
+        assert device
+        assert device.product_type == "HWE-P1"
+
+        device_2 = await api.device(reset_cache=True)
+        assert device_2 != device
+
+        assert device_2.product_type == "HWE-SKT"
+
+        await api.close()
+
+
 @pytest.mark.parametrize(
     ("model", "fixtures"),
     [


### PR DESCRIPTION
The data in `/api` does not change at runtime, only after a firmware update. Cache the device data to reduce unnecessary calls