### PR TITLE
Use custom ssl config for injected clientsession

### DIFF
--- a/homewizard_energy/homewizard_energy.py
+++ b/homewizard_energy/homewizard_energy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from aiohttp.client import ClientSession
+from aiohttp.client import ClientSession, ClientTimeout, TCPConnector
 
 from .const import LOGGER
 from .errors import UnsupportedError
@@ -113,6 +113,25 @@ class HomeWizardEnergy:
         LOGGER.debug("Closing clientsession")
         if self._session and self._close_session:
             await self._session.close()
+
+    async def _create_clientsession(self) -> None:
+        """Create a client session."""
+
+        if self._session is not None:
+            raise RuntimeError("Session already exists")
+
+        connector = TCPConnector(
+            enable_cleanup_closed=True,
+            limit_per_host=1,
+        )
+
+        self._close_session = True
+
+        self._session = ClientSession(
+            connector=connector, timeout=ClientTimeout(total=self._request_timeout)
+        )
+
+        # self._session = self._create_clientsession(connector, timeout=ClientTimeout(total=self._request_timeout))
 
     async def __aenter__(self) -> HomeWizardEnergy:
         """Async enter.

--- a/homewizard_energy/v1/__init__.py
+++ b/homewizard_energy/v1/__init__.py
@@ -9,7 +9,7 @@ from typing import Any, TypeVar
 
 import async_timeout
 import backoff
-from aiohttp.client import ClientError, ClientResponseError, ClientSession
+from aiohttp.client import ClientError, ClientResponseError
 from aiohttp.hdrs import METH_GET, METH_PUT
 
 from ..const import LOGGER
@@ -132,8 +132,7 @@ class HomeWizardEnergyV1(HomeWizardEnergy):
         """Make a request to the API."""
 
         if self._session is None:
-            self._session = ClientSession()
-            self._close_session = True
+            await self._create_clientsession()
 
         # Construct request
         url = f"http://{self.host}/{path}"


### PR DESCRIPTION
Using direct ssl config per request, to allow clientsession injection required for Home Assistant.

Thanks @imicknl !