### PR TITLE
Reapply hotfix 'invalid tariff'

### DIFF
--- a/homewizard_energy/models.py
+++ b/homewizard_energy/models.py
@@ -432,6 +432,17 @@ class Measurement(BaseModel):
 
         return d
 
+    @classmethod
+    def __post_deserialize__(cls, obj: Measurement) -> Measurement:
+        """Post deserialize hook for Measurement object."""
+        _ = cls  # Unused
+
+        # Some smart meters report a tariff other than 1, 2, 3 or 4, which is invalid
+        if obj.tariff not in (1, 2, 3, 4):
+            obj.tariff = None
+
+        return obj
+
 
 @dataclass(kw_only=True)
 class ExternalDevice(BaseModel):

--- a/tests/v1/test_v1_models.py
+++ b/tests/v1/test_v1_models.py
@@ -118,6 +118,14 @@ async def test_data(model: str, fixtures: str, snapshot: SnapshotAssertion):
         assert snapshot == data
 
 
+async def test_data_ignores_invalid_tariff():
+    """Test Data model ignores invalid tariff."""
+
+    measurement = Measurement.from_dict({"active_tariff": 5432})
+    assert measurement
+    assert measurement.tariff is None
+
+
 @pytest.mark.parametrize(
     ("model", "fixtures"),
     [

--- a/tests/v2/test_v2_models.py
+++ b/tests/v2/test_v2_models.py
@@ -59,6 +59,14 @@ async def test_measurement(model: str, fixtures: str, snapshot: SnapshotAssertio
         assert snapshot == data
 
 
+async def test_measurement_ignores_invalid_tariff():
+    """Test Measurement model ignores invalid tariff."""
+
+    measurement = Measurement.from_dict({"tariff": 5432})
+    assert measurement
+    assert measurement.tariff is None
+
+
 @pytest.mark.parametrize(
     ("model", "fixtures"),
     [


### PR DESCRIPTION
Tariff may be a other value than 1,2,3 or 4. Any other value is invalid and will be ignored.