### PR TITLE
Verify partial ssl chains to allow non-pinned certificates

### DIFF
--- a/homewizard_energy/v2/__init__.py
+++ b/homewizard_energy/v2/__init__.py
@@ -195,6 +195,7 @@ class HomeWizardEnergyV2(HomeWizardEnergy):
 
         def _build_ssl_context() -> ssl.SSLContext:
             context = ssl.create_default_context(cadata=CACERT)
+            context.verify_flags = ssl.VERIFY_X509_PARTIAL_CHAIN  # pylint: disable=no-member
             if self._identifier is not None:
                 context.hostname_checks_common_name = True
             else:


### PR DESCRIPTION
When not certificate identifier is given, a certificate with SAN was rejected. We allow that for now until we can correctly retrieve the SAN-identifier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Improvements**
	- Enhanced SSL connection verification to support partial certificate chains
	- Improved SSL context configuration for more robust network connections
<!-- end of auto-generated comment: release notes by coderabbit.ai -->