### PR TITLE
Add _aenter_ helpers to v1 and v2 to allow version-specific functions via 'with ..'

### DIFF
--- a/homewizard_energy/v1/__init__.py
+++ b/homewizard_energy/v1/__init__.py
@@ -173,3 +173,11 @@ class HomeWizardEnergyV1(HomeWizardEnergy):
             raise RequestError(f"API request error ({resp.status})")
 
         return (resp.status, await resp.text())
+
+    async def __aenter__(self) -> HomeWizardEnergyV1:
+        """Async enter.
+
+        Returns:
+            The HomeWizardEnergyV1 object.
+        """
+        return self

--- a/homewizard_energy/v2/__init__.py
+++ b/homewizard_energy/v2/__init__.py
@@ -268,3 +268,11 @@ class HomeWizardEnergyV2(HomeWizardEnergy):
                 pass
 
         return (resp.status, await resp.text())
+
+    async def __aenter__(self) -> HomeWizardEnergyV2:
+        """Async enter.
+
+        Returns:
+            The HomeWizardEnergyV2 object.
+        """
+        return self


### PR DESCRIPTION
`async with HomeWizardEnergyV2(...) as api:` returned a `HomeWizardEnergy`, not a `HomeWizardEnergyV2` according to MyPy. So for this call 'get_token' is not known (as it only exists in `HomeWizardEnergyV2`