### PR TITLE
Add telegram() method to both API versions (#430)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ python3 -m pip install python-homewizard-energy
 ### API v1
 ```python
 import asyncio
-from homewizard_energy import HomeWizardEnergyV1V1
+from homewizard_energy import HomeWizardEnergyV1
 
 IP_ADDRESS = "192.168.1.123"
 

--- a/homewizard_energy/homewizard_energy.py
+++ b/homewizard_energy/homewizard_energy.py
@@ -82,6 +82,10 @@ class HomeWizardEnergy:
         """Get the current measurement."""
         raise NotImplementedError
 
+    async def telegram(self) -> Any:
+        """Get the latest telegram."""
+        raise NotImplementedError
+
     async def system(
         self,
         cloud_enabled: bool | None = None,

--- a/homewizard_energy/v1/__init__.py
+++ b/homewizard_energy/v1/__init__.py
@@ -56,6 +56,15 @@ class HomeWizardEnergyV1(HomeWizardEnergy):
         _, response = await self._request("api/v1/data")
         return Measurement.from_json(response)
 
+    async def telegram(self) -> Any:
+        """Return the most recent, valid telegram that was given by the device.
+        The telegram is not processed in any other form.
+        If you need parsed data, use the measurement method.
+        """
+        _, response = await self._request("api/v1/telegram")
+        telegram = response
+        return telegram
+
     @optional_method
     async def system(
         self,

--- a/homewizard_energy/v2/__init__.py
+++ b/homewizard_energy/v2/__init__.py
@@ -96,6 +96,16 @@ class HomeWizardEnergyV2(HomeWizardEnergy):
         return measurement
 
     @authorized_method
+    async def telegram(self) -> Any:
+        """Return the most recent, valid telegram that was given by the device.
+        The telegram is not processed in any other form.
+        If you need parsed data, use the measurement method.
+        """
+        _, response = await self._request("/api/telegram")
+        telegram = response
+        return telegram
+
+    @authorized_method
     async def system(
         self,
         cloud_enabled: bool | None = None,


### PR DESCRIPTION
This should fix #430.
A new method `telegram()` is added to both API versions v1 and v2.
This returns the output of the `api/v1/telegram` and `api/telegram` endpoints respectively.
All processing is left to the client. Even the return type is not presumed. 